### PR TITLE
Feat: Enable lowercase methods + various minor changes

### DIFF
--- a/src/Method.php
+++ b/src/Method.php
@@ -32,11 +32,13 @@ enum Method: string
         $method = self::tryFromName($name);
 
         if (is_null($method)) {
-            throw new ValueError($name . ' is not a valid name for enum "' . static::class . '"');
+            $enumName = static::class;
+            throw new ValueError("$name is not a valid name for enum \"$enumName\"");
         }
 
         return $method;
     }
+
     public static function tryFromName(?string $name): ?Method
     {
         if (is_null($name)) {

--- a/src/Method.php
+++ b/src/Method.php
@@ -31,7 +31,7 @@ enum Method: string
     {
         $method = self::tryFromName($name);
 
-        if (null === $method) {
+        if (is_null($method)) {
             throw new ValueError($name . ' is not a valid name for enum "' . static::class . '"');
         }
 
@@ -39,7 +39,7 @@ enum Method: string
     }
     public static function tryFromName(?string $name): ?Method
     {
-        if (null === $name) {
+        if (is_null($name)) {
             return null;
         }
 

--- a/src/Method.php
+++ b/src/Method.php
@@ -32,7 +32,7 @@ enum Method: string
         $method = self::tryFromName($name);
 
         if (null === $method) {
-            throw new ValueError(sprintf('%s is not a valid name for enum "%s"', $name, static::class));
+            throw new ValueError($name . ' is not a valid name for enum "' . static::class . '"');
         }
 
         return $method;

--- a/src/Method.php
+++ b/src/Method.php
@@ -53,6 +53,7 @@ enum Method: string
             'OPTIONS' => self::OPTIONS,
             'TRACE' => self::TRACE,
             'PATCH' => self::PATCH,
+            default => null,
         };
     }
 }

--- a/src/Method.php
+++ b/src/Method.php
@@ -29,27 +29,30 @@ enum Method: string
 
     public static function fromName(string $name): Method
     {
-        $method = Method::tryFromName($name);
-        if (is_null($method)) {
-            $enumName = static::class;
-            throw new ValueError("$name is not a valid name for enum \"$enumName\"");
+        $method = self::tryFromName($name);
+
+        if (null === $method) {
+            throw new ValueError(sprintf('%s is not a valid name for enum "%s"', $name, static::class));
         }
+
         return $method;
     }
     public static function tryFromName(?string $name): ?Method
     {
-        return match ($name) {
-            'GET' => Method::GET,
-            'HEAD' => Method::HEAD,
-            'POST' => Method::POST,
-            'PUT' => Method::PUT,
-            'DELETE' => Method::DELETE,
-            'CONNECT' => Method::CONNECT,
-            'OPTIONS' => Method::OPTIONS,
-            'TRACE' => Method::TRACE,
-            'PATCH' => Method::PATCH,
-            null => null,
-            default => null,
+        if (null === $name) {
+            return null;
+        }
+
+        return match (strtoupper($name)) {
+            'GET' => self::GET,
+            'HEAD' => self::HEAD,
+            'POST' => self::POST,
+            'PUT' => self::PUT,
+            'DELETE' => self::DELETE,
+            'CONNECT' => self::CONNECT,
+            'OPTIONS' => self::OPTIONS,
+            'TRACE' => self::TRACE,
+            'PATCH' => self::PATCH,
         };
     }
 }

--- a/src/ReasonPhrase.php
+++ b/src/ReasonPhrase.php
@@ -106,7 +106,7 @@ enum ReasonPhrase: string
     {
         $reasonPhrase = self::tryFromName($name);
 
-        if (null === $reasonPhrase) {
+        if (is_null($reasonPhrase)) {
             throw new ValueError($name . ' is not a valid name for enum "' . static::class . '"');
         }
 
@@ -117,7 +117,7 @@ enum ReasonPhrase: string
     {
         $reasonPhrase = self::tryFromInteger($integer);
 
-        if (null === $reasonPhrase) {
+        if (is_null($reasonPhrase)) {
             throw new ValueError($integer . ' is not a valid value for enum "' . static::class . '"');
         }
 
@@ -202,6 +202,6 @@ enum ReasonPhrase: string
     {
         $statusCode = StatusCode::tryFromInteger($integer);
 
-        return null === $statusCode ? null : self::FromStatusCode($statusCode);
+        return is_null($statusCode) ? null : self::FromStatusCode($statusCode);
     }
 }

--- a/src/ReasonPhrase.php
+++ b/src/ReasonPhrase.php
@@ -104,100 +104,96 @@ enum ReasonPhrase: string
 
     public static function fromName(string $name): ReasonPhrase
     {
-        $reasonPhrase = ReasonPhrase::tryFromName($name);
-        if (is_null($reasonPhrase)) {
-            $enumName = static::class;
-            throw new ValueError("$name is not a valid name for enum \"$enumName\"");
+        $reasonPhrase = self::tryFromName($name);
+
+        if (null === $reasonPhrase) {
+            throw new ValueError(sprintf('%s is not a valid name for enum "%s"', $name, static::class));
         }
+
         return $reasonPhrase;
     }
 
     public static function fromInteger(int $integer): ReasonPhrase
     {
-        $reasonPhrase = ReasonPhrase::tryFromInteger($integer);
-        if (is_null($reasonPhrase)) {
-            $enumName = static::class;
-            throw new ValueError("$integer is not a valid value for enum \"$enumName\"");
+        $reasonPhrase = self::tryFromInteger($integer);
+
+        if (null === $reasonPhrase) {
+            throw new ValueError(sprintf('%s is not a valid name for enum "%s"', $integer, static::class));
         }
+
         return $reasonPhrase;
     }
 
     public static function fromStatusCode(StatusCode $statusCode): ReasonPhrase
     {
-        /**
-         * @var string $statusCode->name
-         */
-        $name = $statusCode->name;
-        $reasonPhrase = ReasonPhrase::fromName($name);
-        return $reasonPhrase;
+        return self::fromName($statusCode->name);
     }
 
     public static function tryFromName(?string $name): ?ReasonPhrase
     {
         return match ($name) {
-            'HTTP_100' => ReasonPhrase::HTTP_100,
-            'HTTP_101' => ReasonPhrase::HTTP_101,
-            'HTTP_102' => ReasonPhrase::HTTP_102,
-            'HTTP_103' => ReasonPhrase::HTTP_103,
-            'HTTP_200' => ReasonPhrase::HTTP_200,
-            'HTTP_201' => ReasonPhrase::HTTP_201,
-            'HTTP_202' => ReasonPhrase::HTTP_202,
-            'HTTP_203' => ReasonPhrase::HTTP_203,
-            'HTTP_204' => ReasonPhrase::HTTP_204,
-            'HTTP_205' => ReasonPhrase::HTTP_205,
-            'HTTP_206' => ReasonPhrase::HTTP_206,
-            'HTTP_207' => ReasonPhrase::HTTP_207,
-            'HTTP_208' => ReasonPhrase::HTTP_208,
-            'HTTP_226' => ReasonPhrase::HTTP_226,
-            'HTTP_300' => ReasonPhrase::HTTP_300,
-            'HTTP_301' => ReasonPhrase::HTTP_301,
-            'HTTP_302' => ReasonPhrase::HTTP_302,
-            'HTTP_303' => ReasonPhrase::HTTP_303,
-            'HTTP_304' => ReasonPhrase::HTTP_304,
-            'HTTP_305' => ReasonPhrase::HTTP_305,
+            'HTTP_100' => self::HTTP_100,
+            'HTTP_101' => self::HTTP_101,
+            'HTTP_102' => self::HTTP_102,
+            'HTTP_103' => self::HTTP_103,
+            'HTTP_200' => self::HTTP_200,
+            'HTTP_201' => self::HTTP_201,
+            'HTTP_202' => self::HTTP_202,
+            'HTTP_203' => self::HTTP_203,
+            'HTTP_204' => self::HTTP_204,
+            'HTTP_205' => self::HTTP_205,
+            'HTTP_206' => self::HTTP_206,
+            'HTTP_207' => self::HTTP_207,
+            'HTTP_208' => self::HTTP_208,
+            'HTTP_226' => self::HTTP_226,
+            'HTTP_300' => self::HTTP_300,
+            'HTTP_301' => self::HTTP_301,
+            'HTTP_302' => self::HTTP_302,
+            'HTTP_303' => self::HTTP_303,
+            'HTTP_304' => self::HTTP_304,
+            'HTTP_305' => self::HTTP_305,
             'HTTP_306' => null, // intentionally null
-            'HTTP_307' => ReasonPhrase::HTTP_307,
-            'HTTP_308' => ReasonPhrase::HTTP_308,
-            'HTTP_400' => ReasonPhrase::HTTP_400,
-            'HTTP_401' => ReasonPhrase::HTTP_401,
-            'HTTP_402' => ReasonPhrase::HTTP_402,
-            'HTTP_403' => ReasonPhrase::HTTP_403,
-            'HTTP_404' => ReasonPhrase::HTTP_404,
-            'HTTP_405' => ReasonPhrase::HTTP_405,
-            'HTTP_406' => ReasonPhrase::HTTP_406,
-            'HTTP_407' => ReasonPhrase::HTTP_407,
-            'HTTP_408' => ReasonPhrase::HTTP_408,
-            'HTTP_409' => ReasonPhrase::HTTP_409,
-            'HTTP_410' => ReasonPhrase::HTTP_410,
-            'HTTP_411' => ReasonPhrase::HTTP_411,
-            'HTTP_412' => ReasonPhrase::HTTP_412,
-            'HTTP_413' => ReasonPhrase::HTTP_413,
-            'HTTP_414' => ReasonPhrase::HTTP_414,
-            'HTTP_415' => ReasonPhrase::HTTP_415,
-            'HTTP_416' => ReasonPhrase::HTTP_416,
-            'HTTP_417' => ReasonPhrase::HTTP_417,
-            'HTTP_421' => ReasonPhrase::HTTP_421,
-            'HTTP_422' => ReasonPhrase::HTTP_422,
-            'HTTP_423' => ReasonPhrase::HTTP_423,
-            'HTTP_424' => ReasonPhrase::HTTP_424,
-            'HTTP_425' => ReasonPhrase::HTTP_425,
-            'HTTP_426' => ReasonPhrase::HTTP_426,
-            'HTTP_428' => ReasonPhrase::HTTP_428,
-            'HTTP_429' => ReasonPhrase::HTTP_429,
-            'HTTP_431' => ReasonPhrase::HTTP_431,
-            'HTTP_451' => ReasonPhrase::HTTP_451,
-            'HTTP_500' => ReasonPhrase::HTTP_500,
-            'HTTP_501' => ReasonPhrase::HTTP_501,
-            'HTTP_502' => ReasonPhrase::HTTP_502,
-            'HTTP_503' => ReasonPhrase::HTTP_503,
-            'HTTP_504' => ReasonPhrase::HTTP_504,
-            'HTTP_505' => ReasonPhrase::HTTP_505,
-            'HTTP_506' => ReasonPhrase::HTTP_506,
-            'HTTP_507' => ReasonPhrase::HTTP_507,
-            'HTTP_508' => ReasonPhrase::HTTP_508,
-            'HTTP_510' => ReasonPhrase::HTTP_510,
-            'HTTP_511' => ReasonPhrase::HTTP_511,
-            null => null,
+            'HTTP_307' => self::HTTP_307,
+            'HTTP_308' => self::HTTP_308,
+            'HTTP_400' => self::HTTP_400,
+            'HTTP_401' => self::HTTP_401,
+            'HTTP_402' => self::HTTP_402,
+            'HTTP_403' => self::HTTP_403,
+            'HTTP_404' => self::HTTP_404,
+            'HTTP_405' => self::HTTP_405,
+            'HTTP_406' => self::HTTP_406,
+            'HTTP_407' => self::HTTP_407,
+            'HTTP_408' => self::HTTP_408,
+            'HTTP_409' => self::HTTP_409,
+            'HTTP_410' => self::HTTP_410,
+            'HTTP_411' => self::HTTP_411,
+            'HTTP_412' => self::HTTP_412,
+            'HTTP_413' => self::HTTP_413,
+            'HTTP_414' => self::HTTP_414,
+            'HTTP_415' => self::HTTP_415,
+            'HTTP_416' => self::HTTP_416,
+            'HTTP_417' => self::HTTP_417,
+            'HTTP_421' => self::HTTP_421,
+            'HTTP_422' => self::HTTP_422,
+            'HTTP_423' => self::HTTP_423,
+            'HTTP_424' => self::HTTP_424,
+            'HTTP_425' => self::HTTP_425,
+            'HTTP_426' => self::HTTP_426,
+            'HTTP_428' => self::HTTP_428,
+            'HTTP_429' => self::HTTP_429,
+            'HTTP_431' => self::HTTP_431,
+            'HTTP_451' => self::HTTP_451,
+            'HTTP_500' => self::HTTP_500,
+            'HTTP_501' => self::HTTP_501,
+            'HTTP_502' => self::HTTP_502,
+            'HTTP_503' => self::HTTP_503,
+            'HTTP_504' => self::HTTP_504,
+            'HTTP_505' => self::HTTP_505,
+            'HTTP_506' => self::HTTP_506,
+            'HTTP_507' => self::HTTP_507,
+            'HTTP_508' => self::HTTP_508,
+            'HTTP_510' => self::HTTP_510,
+            'HTTP_511' => self::HTTP_511,
             default => null,
         };
     }
@@ -205,9 +201,7 @@ enum ReasonPhrase: string
     public static function tryFromInteger(?int $integer): ?ReasonPhrase
     {
         $statusCode = StatusCode::tryFromInteger($integer);
-        if (is_null($statusCode)) {
-            return null;
-        }
-        return ReasonPhrase::FromStatusCode($statusCode);
+
+        return null === $statusCode ? null : self::FromStatusCode($statusCode);
     }
 }

--- a/src/ReasonPhrase.php
+++ b/src/ReasonPhrase.php
@@ -107,7 +107,8 @@ enum ReasonPhrase: string
         $reasonPhrase = self::tryFromName($name);
 
         if (is_null($reasonPhrase)) {
-            throw new ValueError($name . ' is not a valid name for enum "' . static::class . '"');
+            $enumName = static::class;
+            throw new ValueError("$name is not a valid name for enum \"$enumName\"");
         }
 
         return $reasonPhrase;
@@ -118,7 +119,8 @@ enum ReasonPhrase: string
         $reasonPhrase = self::tryFromInteger($integer);
 
         if (is_null($reasonPhrase)) {
-            throw new ValueError($integer . ' is not a valid value for enum "' . static::class . '"');
+            $enumName = static::class;
+            throw new ValueError("$integer is not a valid value for enum \"$enumName\"");
         }
 
         return $reasonPhrase;
@@ -126,6 +128,9 @@ enum ReasonPhrase: string
 
     public static function fromStatusCode(StatusCode $statusCode): ReasonPhrase
     {
+        /**
+         * @var string $statusCode->name
+         */
         return self::fromName($statusCode->name);
     }
 
@@ -201,7 +206,9 @@ enum ReasonPhrase: string
     public static function tryFromInteger(?int $integer): ?ReasonPhrase
     {
         $statusCode = StatusCode::tryFromInteger($integer);
-
-        return is_null($statusCode) ? null : self::FromStatusCode($statusCode);
+        if (is_null($statusCode)) {
+            return null;
+        }
+        return self::FromStatusCode($statusCode);
     }
 }

--- a/src/ReasonPhrase.php
+++ b/src/ReasonPhrase.php
@@ -107,7 +107,7 @@ enum ReasonPhrase: string
         $reasonPhrase = self::tryFromName($name);
 
         if (null === $reasonPhrase) {
-            throw new ValueError(sprintf('%s is not a valid name for enum "%s"', $name, static::class));
+            throw new ValueError($name . ' is not a valid name for enum "' . static::class . '"');
         }
 
         return $reasonPhrase;
@@ -118,7 +118,7 @@ enum ReasonPhrase: string
         $reasonPhrase = self::tryFromInteger($integer);
 
         if (null === $reasonPhrase) {
-            throw new ValueError(sprintf('%s is not a valid name for enum "%s"', $integer, static::class));
+            throw new ValueError($integer . ' is not a valid value for enum "' . static::class . '"');
         }
 
         return $reasonPhrase;

--- a/src/StatusCode.php
+++ b/src/StatusCode.php
@@ -106,7 +106,7 @@ enum StatusCode: int
     {
         $statusCode = self::tryFromName($name);
 
-        if (null === $statusCode) {
+        if (is_null($statusCode)) {
             throw new ValueError($name . ' is not a valid name for enum "' . static::class . '"');
         }
 
@@ -117,7 +117,7 @@ enum StatusCode: int
     {
         $statusCode = self::tryFromInteger($integer);
 
-        if (null === $statusCode) {
+        if (is_null($statusCode)) {
             throw new ValueError($integer . ' is not a valid value for enum "' . static::class . '"');
         }
 
@@ -200,6 +200,6 @@ enum StatusCode: int
 
     public static function tryFromInteger(?int $integer): ?StatusCode
     {
-        return null === $integer ? null : self::tryFrom($integer);
+        return is_null($integer) ? null : self::tryFrom($integer);
     }
 }

--- a/src/StatusCode.php
+++ b/src/StatusCode.php
@@ -104,114 +104,102 @@ enum StatusCode: int
 
     public static function fromName(string $name): StatusCode
     {
-        $statusCode = StatusCode::tryFromName($name);
-        if (is_null($statusCode)) {
-            $enumName = static::class;
-            throw new ValueError("$name is not a valid name for enum \"$enumName\"");
+        $statusCode = self::tryFromName($name);
+
+        if (null === $statusCode) {
+            throw new ValueError(sprintf('%s is not a valid name for enum "%s"', $name, static::class));
         }
+
         return $statusCode;
     }
 
     public static function fromInteger(int $integer): StatusCode
     {
-        $statusCode = StatusCode::tryFromInteger($integer);
-        if (is_null($statusCode)) {
-            $enumName = static::class;
-            throw new ValueError("$integer is not a valid value for enum \"$enumName\"");
+        $statusCode = self::tryFromInteger($integer);
+
+        if (null === $statusCode) {
+            throw new ValueError(sprintf('%s is not a valid value for enum "%s"', $integer, static::class));
         }
+
         return $statusCode;
     }
 
     public static function fromReasonPhrase(ReasonPhrase $reasonPhrase): StatusCode
     {
-        /**
-         * @var string $reasonPhrase->name
-         */
-        $name = $reasonPhrase->name;
-        $statusCode = StatusCode::fromName($name);
-        return $statusCode;
+        return self::fromName($reasonPhrase->name);
     }
 
     public static function tryFromName(?string $name): ?StatusCode
     {
         return match ($name) {
-            'HTTP_100' => StatusCode::HTTP_100,
-            'HTTP_101' => StatusCode::HTTP_101,
-            'HTTP_102' => StatusCode::HTTP_102,
-            'HTTP_103' => StatusCode::HTTP_103,
-            'HTTP_200' => StatusCode::HTTP_200,
-            'HTTP_201' => StatusCode::HTTP_201,
-            'HTTP_202' => StatusCode::HTTP_202,
-            'HTTP_203' => StatusCode::HTTP_203,
-            'HTTP_204' => StatusCode::HTTP_204,
-            'HTTP_205' => StatusCode::HTTP_205,
-            'HTTP_206' => StatusCode::HTTP_206,
-            'HTTP_207' => StatusCode::HTTP_207,
-            'HTTP_208' => StatusCode::HTTP_208,
-            'HTTP_226' => StatusCode::HTTP_226,
-            'HTTP_300' => StatusCode::HTTP_300,
-            'HTTP_301' => StatusCode::HTTP_301,
-            'HTTP_302' => StatusCode::HTTP_302,
-            'HTTP_303' => StatusCode::HTTP_303,
-            'HTTP_304' => StatusCode::HTTP_304,
-            'HTTP_305' => StatusCode::HTTP_305,
+            'HTTP_100' => self::HTTP_100,
+            'HTTP_101' => self::HTTP_101,
+            'HTTP_102' => self::HTTP_102,
+            'HTTP_103' => self::HTTP_103,
+            'HTTP_200' => self::HTTP_200,
+            'HTTP_201' => self::HTTP_201,
+            'HTTP_202' => self::HTTP_202,
+            'HTTP_203' => self::HTTP_203,
+            'HTTP_204' => self::HTTP_204,
+            'HTTP_205' => self::HTTP_205,
+            'HTTP_206' => self::HTTP_206,
+            'HTTP_207' => self::HTTP_207,
+            'HTTP_208' => self::HTTP_208,
+            'HTTP_226' => self::HTTP_226,
+            'HTTP_300' => self::HTTP_300,
+            'HTTP_301' => self::HTTP_301,
+            'HTTP_302' => self::HTTP_302,
+            'HTTP_303' => self::HTTP_303,
+            'HTTP_304' => self::HTTP_304,
+            'HTTP_305' => self::HTTP_305,
             'HTTP_306' => null, // intentionally null
-            'HTTP_307' => StatusCode::HTTP_307,
-            'HTTP_308' => StatusCode::HTTP_308,
-            'HTTP_400' => StatusCode::HTTP_400,
-            'HTTP_401' => StatusCode::HTTP_401,
-            'HTTP_402' => StatusCode::HTTP_402,
-            'HTTP_403' => StatusCode::HTTP_403,
-            'HTTP_404' => StatusCode::HTTP_404,
-            'HTTP_405' => StatusCode::HTTP_405,
-            'HTTP_406' => StatusCode::HTTP_406,
-            'HTTP_407' => StatusCode::HTTP_407,
-            'HTTP_408' => StatusCode::HTTP_408,
-            'HTTP_409' => StatusCode::HTTP_409,
-            'HTTP_410' => StatusCode::HTTP_410,
-            'HTTP_411' => StatusCode::HTTP_411,
-            'HTTP_412' => StatusCode::HTTP_412,
-            'HTTP_413' => StatusCode::HTTP_413,
-            'HTTP_414' => StatusCode::HTTP_414,
-            'HTTP_415' => StatusCode::HTTP_415,
-            'HTTP_416' => StatusCode::HTTP_416,
-            'HTTP_417' => StatusCode::HTTP_417,
-            'HTTP_421' => StatusCode::HTTP_421,
-            'HTTP_422' => StatusCode::HTTP_422,
-            'HTTP_423' => StatusCode::HTTP_423,
-            'HTTP_424' => StatusCode::HTTP_424,
-            'HTTP_425' => StatusCode::HTTP_425,
-            'HTTP_426' => StatusCode::HTTP_426,
-            'HTTP_428' => StatusCode::HTTP_428,
-            'HTTP_429' => StatusCode::HTTP_429,
-            'HTTP_431' => StatusCode::HTTP_431,
-            'HTTP_451' => StatusCode::HTTP_451,
-            'HTTP_500' => StatusCode::HTTP_500,
-            'HTTP_501' => StatusCode::HTTP_501,
-            'HTTP_502' => StatusCode::HTTP_502,
-            'HTTP_503' => StatusCode::HTTP_503,
-            'HTTP_504' => StatusCode::HTTP_504,
-            'HTTP_505' => StatusCode::HTTP_505,
-            'HTTP_506' => StatusCode::HTTP_506,
-            'HTTP_507' => StatusCode::HTTP_507,
-            'HTTP_508' => StatusCode::HTTP_508,
-            'HTTP_510' => StatusCode::HTTP_510,
-            'HTTP_511' => StatusCode::HTTP_511,
-            null => null,
+            'HTTP_307' => self::HTTP_307,
+            'HTTP_308' => self::HTTP_308,
+            'HTTP_400' => self::HTTP_400,
+            'HTTP_401' => self::HTTP_401,
+            'HTTP_402' => self::HTTP_402,
+            'HTTP_403' => self::HTTP_403,
+            'HTTP_404' => self::HTTP_404,
+            'HTTP_405' => self::HTTP_405,
+            'HTTP_406' => self::HTTP_406,
+            'HTTP_407' => self::HTTP_407,
+            'HTTP_408' => self::HTTP_408,
+            'HTTP_409' => self::HTTP_409,
+            'HTTP_410' => self::HTTP_410,
+            'HTTP_411' => self::HTTP_411,
+            'HTTP_412' => self::HTTP_412,
+            'HTTP_413' => self::HTTP_413,
+            'HTTP_414' => self::HTTP_414,
+            'HTTP_415' => self::HTTP_415,
+            'HTTP_416' => self::HTTP_416,
+            'HTTP_417' => self::HTTP_417,
+            'HTTP_421' => self::HTTP_421,
+            'HTTP_422' => self::HTTP_422,
+            'HTTP_423' => self::HTTP_423,
+            'HTTP_424' => self::HTTP_424,
+            'HTTP_425' => self::HTTP_425,
+            'HTTP_426' => self::HTTP_426,
+            'HTTP_428' => self::HTTP_428,
+            'HTTP_429' => self::HTTP_429,
+            'HTTP_431' => self::HTTP_431,
+            'HTTP_451' => self::HTTP_451,
+            'HTTP_500' => self::HTTP_500,
+            'HTTP_501' => self::HTTP_501,
+            'HTTP_502' => self::HTTP_502,
+            'HTTP_503' => self::HTTP_503,
+            'HTTP_504' => self::HTTP_504,
+            'HTTP_505' => self::HTTP_505,
+            'HTTP_506' => self::HTTP_506,
+            'HTTP_507' => self::HTTP_507,
+            'HTTP_508' => self::HTTP_508,
+            'HTTP_510' => self::HTTP_510,
+            'HTTP_511' => self::HTTP_511,
             default => null,
         };
     }
 
     public static function tryFromInteger(?int $integer): ?StatusCode
     {
-        if (is_null($integer)) {
-            return null;
-        }
-        /**
-         * @var ?StatusCode
-         * @psalm-suppress UndefinedMethod
-         */
-        $statusCode = StatusCode::tryFrom($integer);
-        return $statusCode;
+        return null === $integer ? null : self::tryFrom($integer);
     }
 }

--- a/src/StatusCode.php
+++ b/src/StatusCode.php
@@ -107,7 +107,7 @@ enum StatusCode: int
         $statusCode = self::tryFromName($name);
 
         if (null === $statusCode) {
-            throw new ValueError(sprintf('%s is not a valid name for enum "%s"', $name, static::class));
+            throw new ValueError($name . ' is not a valid name for enum "' . static::class . '"');
         }
 
         return $statusCode;
@@ -118,7 +118,7 @@ enum StatusCode: int
         $statusCode = self::tryFromInteger($integer);
 
         if (null === $statusCode) {
-            throw new ValueError(sprintf('%s is not a valid value for enum "%s"', $integer, static::class));
+            throw new ValueError($integer . ' is not a valid value for enum "' . static::class . '"');
         }
 
         return $statusCode;

--- a/src/StatusCode.php
+++ b/src/StatusCode.php
@@ -107,7 +107,8 @@ enum StatusCode: int
         $statusCode = self::tryFromName($name);
 
         if (is_null($statusCode)) {
-            throw new ValueError($name . ' is not a valid name for enum "' . static::class . '"');
+            $enumName = static::class;
+            throw new ValueError("$name is not a valid name for enum \"$enumName\"");
         }
 
         return $statusCode;
@@ -118,7 +119,8 @@ enum StatusCode: int
         $statusCode = self::tryFromInteger($integer);
 
         if (is_null($statusCode)) {
-            throw new ValueError($integer . ' is not a valid value for enum "' . static::class . '"');
+            $enumName = static::class;
+            throw new ValueError("$integer is not a valid value for enum \"$enumName\"");
         }
 
         return $statusCode;
@@ -126,6 +128,9 @@ enum StatusCode: int
 
     public static function fromReasonPhrase(ReasonPhrase $reasonPhrase): StatusCode
     {
+        /**
+         * @var string $reasonPhrase->name
+         */
         return self::fromName($reasonPhrase->name);
     }
 
@@ -200,6 +205,15 @@ enum StatusCode: int
 
     public static function tryFromInteger(?int $integer): ?StatusCode
     {
-        return is_null($integer) ? null : self::tryFrom($integer);
+        if (is_null($integer)) {
+            return null;
+        }
+
+        /**
+         * @var ?StatusCode
+         * @psalm-suppress UndefinedMethod
+         */
+        $statusCode = self::tryFrom($integer);
+        return $statusCode;
     }
 }

--- a/tests/MethodNamedTest.php
+++ b/tests/MethodNamedTest.php
@@ -41,6 +41,13 @@ class MethodNamedTest extends TestCase
             $name = $case->name;
             $method = Method::fromName(name: $name);
             Assert::assertThat($method, Assert::identicalTo($case));
+
+            /**
+             * @var string $case->name
+             */
+            $name = strtolower($case->name);
+            $method = Method::fromName(name: $name);
+            Assert::assertThat($method, Assert::identicalTo($case));
         }
     }
 
@@ -51,6 +58,13 @@ class MethodNamedTest extends TestCase
              * @var string $case->name
              */
             $name = $case->name;
+            $method = Method::tryFromName(name: $name);
+            Assert::assertThat($method, Assert::identicalTo($case));
+
+            /**
+             * @var string $case->name
+             */
+            $name = strtolower($case->name);
             $method = Method::tryFromName(name: $name);
             Assert::assertThat($method, Assert::identicalTo($case));
         }

--- a/tests/MethodNamedTest.php
+++ b/tests/MethodNamedTest.php
@@ -32,16 +32,33 @@ class MethodNamedTest extends TestCase
         $this->cases = Method::cases();
     }
 
-    public function testFromNames(): void
+    public function testCaconicalNameCapitalization(): void
     {
         foreach ($this->cases as $case) {
             /**
              * @var string $case->name
              */
             $name = $case->name;
+            $canonicalName = strtoupper($case->name);
+            Assert::assertThat($name, Assert::identicalTo($canonicalName));
+        }
+    }
+
+    public function testFromNamesUppercase(): void
+    {
+        foreach ($this->cases as $case) {
+            /**
+             * @var string $case->name
+             */
+            $name = strtoupper($case->name);
             $method = Method::fromName(name: $name);
             Assert::assertThat($method, Assert::identicalTo($case));
+        }
+    }
 
+    public function testFromNamesLowercase(): void
+    {
+        foreach ($this->cases as $case) {
             /**
              * @var string $case->name
              */
@@ -51,20 +68,73 @@ class MethodNamedTest extends TestCase
         }
     }
 
-    public function testTryFromNames(): void
+    public function testFromNamesTitlecase(): void
     {
         foreach ($this->cases as $case) {
             /**
              * @var string $case->name
              */
-            $name = $case->name;
+            $name = ucfirst(strtolower($case->name));
+            $method = Method::fromName(name: $name);
+            Assert::assertThat($method, Assert::identicalTo($case));
+        }
+    }
+
+    public function testFromNamesInvertedTitlecase(): void
+    {
+        foreach ($this->cases as $case) {
+            /**
+             * @var string $case->name
+             */
+            $name = lcfirst(strtoupper($case->name));
+            $method = Method::fromName(name: $name);
+            Assert::assertThat($method, Assert::identicalTo($case));
+        }
+    }
+
+    public function testTryFromNamesUppercase(): void
+    {
+        foreach ($this->cases as $case) {
+            /**
+             * @var string $case->name
+             */
+            $name = strtoupper($case->name);
             $method = Method::tryFromName(name: $name);
             Assert::assertThat($method, Assert::identicalTo($case));
+        }
+    }
 
+    public function testTryFromNamesLowercase(): void
+    {
+        foreach ($this->cases as $case) {
             /**
              * @var string $case->name
              */
             $name = strtolower($case->name);
+            $method = Method::tryFromName(name: $name);
+            Assert::assertThat($method, Assert::identicalTo($case));
+        }
+    }
+
+    public function testTryFromNamesTitlecase(): void
+    {
+        foreach ($this->cases as $case) {
+            /**
+             * @var string $case->name
+             */
+            $name = ucfirst(strtolower($case->name));
+            $method = Method::tryFromName(name: $name);
+            Assert::assertThat($method, Assert::identicalTo($case));
+        }
+    }
+
+    public function testTryFromNamesInvertedTitlecase(): void
+    {
+        foreach ($this->cases as $case) {
+            /**
+             * @var string $case->name
+             */
+            $name = lcfirst(strtoupper($case->name));
             $method = Method::tryFromName(name: $name);
             Assert::assertThat($method, Assert::identicalTo($case));
         }

--- a/tests/MethodPositionalTest.php
+++ b/tests/MethodPositionalTest.php
@@ -32,16 +32,33 @@ class MethodPositionalTest extends TestCase
         $this->cases = Method::cases();
     }
 
-    public function testFromNames(): void
+    public function testCaconicalNameCapitalization(): void
     {
         foreach ($this->cases as $case) {
             /**
              * @var string $case->name
              */
             $name = $case->name;
+            $canonicalName = strtoupper($case->name);
+            Assert::assertThat($name, Assert::identicalTo($canonicalName));
+        }
+    }
+
+    public function testFromNamesUppercase(): void
+    {
+        foreach ($this->cases as $case) {
+            /**
+             * @var string $case->name
+             */
+            $name = strtoupper($case->name);
             $method = Method::fromName($name);
             Assert::assertThat($method, Assert::identicalTo($case));
+        }
+    }
 
+    public function testFromNamesLowercase(): void
+    {
+        foreach ($this->cases as $case) {
             /**
              * @var string $case->name
              */
@@ -51,20 +68,73 @@ class MethodPositionalTest extends TestCase
         }
     }
 
-    public function testTryFromNames(): void
+    public function testFromNamesTitlecase(): void
     {
         foreach ($this->cases as $case) {
             /**
              * @var string $case->name
              */
-            $name = $case->name;
+            $name = ucfirst(strtolower($case->name));
+            $method = Method::fromName($name);
+            Assert::assertThat($method, Assert::identicalTo($case));
+        }
+    }
+
+    public function testFromNamesInvertedTitlecase(): void
+    {
+        foreach ($this->cases as $case) {
+            /**
+             * @var string $case->name
+             */
+            $name = lcfirst(strtoupper($case->name));
+            $method = Method::fromName($name);
+            Assert::assertThat($method, Assert::identicalTo($case));
+        }
+    }
+
+    public function testTryFromNamesUppercase(): void
+    {
+        foreach ($this->cases as $case) {
+            /**
+             * @var string $case->name
+             */
+            $name = strtoupper($case->name);
             $method = Method::tryFromName($name);
             Assert::assertThat($method, Assert::identicalTo($case));
+        }
+    }
 
+    public function testTryFromNamesLowercase(): void
+    {
+        foreach ($this->cases as $case) {
             /**
              * @var string $case->name
              */
             $name = strtolower($case->name);
+            $method = Method::tryFromName($name);
+            Assert::assertThat($method, Assert::identicalTo($case));
+        }
+    }
+
+    public function testTryFromNamesTitlecase(): void
+    {
+        foreach ($this->cases as $case) {
+            /**
+             * @var string $case->name
+             */
+            $name = ucfirst(strtolower($case->name));
+            $method = Method::tryFromName($name);
+            Assert::assertThat($method, Assert::identicalTo($case));
+        }
+    }
+
+    public function testTryFromNamesInvertedTitlecase(): void
+    {
+        foreach ($this->cases as $case) {
+            /**
+             * @var string $case->name
+             */
+            $name = lcfirst(strtoupper($case->name));
             $method = Method::tryFromName($name);
             Assert::assertThat($method, Assert::identicalTo($case));
         }

--- a/tests/MethodPositionalTest.php
+++ b/tests/MethodPositionalTest.php
@@ -41,6 +41,13 @@ class MethodPositionalTest extends TestCase
             $name = $case->name;
             $method = Method::fromName($name);
             Assert::assertThat($method, Assert::identicalTo($case));
+
+            /**
+             * @var string $case->name
+             */
+            $name = strtolower($case->name);
+            $method = Method::fromName($name);
+            Assert::assertThat($method, Assert::identicalTo($case));
         }
     }
 
@@ -51,6 +58,13 @@ class MethodPositionalTest extends TestCase
              * @var string $case->name
              */
             $name = $case->name;
+            $method = Method::tryFromName($name);
+            Assert::assertThat($method, Assert::identicalTo($case));
+
+            /**
+             * @var string $case->name
+             */
+            $name = strtolower($case->name);
             $method = Method::tryFromName($name);
             Assert::assertThat($method, Assert::identicalTo($case));
         }


### PR DESCRIPTION
Hey hi!

Thanks for this package, I get it will be useful when 8.1 will be the default PHP version :)

I made minor changes, but I was unable to test that locally as I don't have php 8.1 available yet on Nixos.

Among the changes, here are the list:

1. Insensitive case HTTP methods
2. Replace `is_null()` with `null ===`
3. Use `self`
4. Reduce amount of local variables here and there

Let me know what you think!

Regards.